### PR TITLE
Fixed issue when configuring without processing iptables. Fixed issue with backup script when backup directory did not exist.

### DIFF
--- a/backup/processors/backup.sh
+++ b/backup/processors/backup.sh
@@ -27,7 +27,7 @@ log "STARTING BACKUP $TIMESTAMP"
 # We rm -rf on BACKUP_FOLDER, this is to prevent disasters in case the variable is not set
 BACKUP_ROOT="${BACKUP_ROOT:-$HOME/services/backup}"
 BACKUP_FOLDER="${BACKUP_FOLDER:-$BACKUP_ROOT/backup}"
-
+mkdir -p $BACKUP_FOLDER
 
 # Set up the trap to call the handle_exit function on script termination
 # We execute send_email.sh regardless if backup.sh fails or not

--- a/utils/env_set.py
+++ b/utils/env_set.py
@@ -99,22 +99,19 @@ class EnvironmentConfigurator():
 if __name__== "__main__":
     
     parser = argparse.ArgumentParser(description='Sets Environment Vars for .env files')
-    parser.add_argument('process_iptables', type=str, help='Whether to process IPTABLES')
+    parser.add_argument('--process_iptables', action='store_true', help='Whether to process IPTABLES')
     args = parser.parse_args()
-
-    if args.process_iptables == "process_iptables":
-        process_iptables = True
         
     services_home = os.getenv("SERVICES_HOME")
         
     config_path = f"{services_home}/utils/config.conf"
     map_file_path = f"{services_home}/utils/map.json"
-    map_file_iptables_path = f"{services_home}/utils/map_iptables.json" if process_iptables else None
+    map_file_iptables_path = f"{services_home}/utils/map_iptables.json" if args.process_iptables else None
         
     configurator = EnvironmentConfigurator(config_file_path=config_path,
                                           map_file_path=map_file_path,
                                           map_file_iptables_path=map_file_iptables_path,
                                           services_home = services_home)
     configurator.map_env_vars()
-    if process_iptables:
+    if args.process_iptables:
         configurator.map_env_vars_iptables()

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -367,7 +367,7 @@ install_docker(){
 
 set_environment_files () {
     if [ "$include_iptables" = true ]; then
-        python env_set.py "process_iptables"
+        python env_set.py --process_iptables
     else
         python env_set.py
     fi


### PR DESCRIPTION
### Process iptables
Affects: **env_set.py**, **install.sh**
Positional arguments in Python's argparse are always mandatory. Trying to run env_set.py without any arguments throws an error. This changes the **process_iptables** option to an optional boolean flag.

### Backup script directory
Affects: **backup.sh**
The script fails if the backup folder path doesn't currently exist. I added a simple check to make sure the directory exists in the container before continuing with the backup.